### PR TITLE
[feat] #16 스플래쉬 Lottie 애니메이션 디자인 수정사항에 맞게 구현

### DIFF
--- a/feature/splash/src/main/java/org/prography/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/org/prography/splash/SplashScreen.kt
@@ -37,11 +37,47 @@ fun SplashScreen(navHostController: NavHostController = rememberNavController())
         val lottieComposition by rememberLottieComposition(spec = LottieCompositionSpec.Asset("grid_animation.json"))
         val logoAnimationState = animateLottieCompositionAsState(lottieComposition)
 
-        LottieAnimation(
-            composition = lottieComposition,
-            progress = { logoAnimationState.progress },
-            contentScale = ContentScale.FillHeight,
-        )
+        Column {
+            LottieAnimation(
+                composition = lottieComposition,
+                progress = { logoAnimationState.progress },
+                modifier = Modifier.weight(1f),
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.TopCenter
+            )
+
+            LottieAnimation(
+                composition = lottieComposition,
+                progress = { logoAnimationState.progress },
+                modifier = Modifier.weight(1f),
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.TopCenter
+            )
+
+            LottieAnimation(
+                composition = lottieComposition,
+                progress = { logoAnimationState.progress },
+                modifier = Modifier.weight(1f),
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.TopCenter
+            )
+
+            LottieAnimation(
+                composition = lottieComposition,
+                progress = { logoAnimationState.progress },
+                modifier = Modifier.weight(1f),
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.TopCenter
+            )
+
+            LottieAnimation(
+                composition = lottieComposition,
+                progress = { logoAnimationState.progress },
+                modifier = Modifier.weight(1f),
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.TopCenter
+            )
+        }
 
         if (logoAnimationState.isAtEnd && logoAnimationState.isPlaying) {
             navHostController.navigate(CakkDestination.OnBoarding.route) {

--- a/feature/splash/src/main/java/org/prography/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/org/prography/splash/SplashScreen.kt
@@ -38,45 +38,15 @@ fun SplashScreen(navHostController: NavHostController = rememberNavController())
         val logoAnimationState = animateLottieCompositionAsState(lottieComposition)
 
         Column {
-            LottieAnimation(
-                composition = lottieComposition,
-                progress = { logoAnimationState.progress },
-                modifier = Modifier.weight(1f),
-                contentScale = ContentScale.FillWidth,
-                alignment = Alignment.TopCenter
-            )
-
-            LottieAnimation(
-                composition = lottieComposition,
-                progress = { logoAnimationState.progress },
-                modifier = Modifier.weight(1f),
-                contentScale = ContentScale.FillWidth,
-                alignment = Alignment.TopCenter
-            )
-
-            LottieAnimation(
-                composition = lottieComposition,
-                progress = { logoAnimationState.progress },
-                modifier = Modifier.weight(1f),
-                contentScale = ContentScale.FillWidth,
-                alignment = Alignment.TopCenter
-            )
-
-            LottieAnimation(
-                composition = lottieComposition,
-                progress = { logoAnimationState.progress },
-                modifier = Modifier.weight(1f),
-                contentScale = ContentScale.FillWidth,
-                alignment = Alignment.TopCenter
-            )
-
-            LottieAnimation(
-                composition = lottieComposition,
-                progress = { logoAnimationState.progress },
-                modifier = Modifier.weight(1f),
-                contentScale = ContentScale.FillWidth,
-                alignment = Alignment.TopCenter
-            )
+            (0..4).forEach {
+                LottieAnimation(
+                    composition = lottieComposition,
+                    progress = { logoAnimationState.progress },
+                    modifier = Modifier.weight(1f),
+                    contentScale = ContentScale.FillWidth,
+                    alignment = Alignment.TopCenter
+                )
+            }
         }
 
         if (logoAnimationState.isAtEnd && logoAnimationState.isPlaying) {


### PR DESCRIPTION
## Related issue
- closed #16 

## Work Description
- 스플래쉬 애니메이션 디자인 수정

## Screenshot 
<img src="https://github.com/Prography-8th-team8/Cakk-AOS/assets/34837583/fedee74d-d615-479b-9559-d6aec7d800e1" width=300 height=650/>


## Completed Tasks
- [x]  스플래쉬 lottin 애니메이션 확대 처리가 아닌 이미지 5개로 변경
