### PR TITLE
[feat] 홈 지도 화면 MVI 적용 및 관련 로직 수정 

### DIFF
--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -22,8 +22,12 @@ fun CakkNavigationGraph(navController: NavHostController) {
             SplashScreen(navHostController = navController)
         }
 
-        composable(route = CakkDestination.Home.route) {
-            HomeScreen(navHostController = navController)
+        composable(
+            route = CakkDestination.Home.routeWithArgs,
+            arguments = CakkDestination.Home.arguments
+        ) { navBackStackEntry ->
+            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.districtsArgs)
+            HomeScreen(navHostController = navController, districts = districts)
         }
 
         composable(

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -28,7 +28,21 @@ fun CakkNavigationGraph(navController: NavHostController) {
         ) { navBackStackEntry ->
             val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.DISTRICTS_INFO)
             val storeCount = navBackStackEntry.arguments?.getInt(CakkDestination.Home.STORE_COUNT)
-            HomeScreen(navHostController = navController, districtsArg = districts, storeCountArg = storeCount)
+            HomeScreen(
+                navHostController = navController,
+                districtsArg = districts,
+                storeCountArg = storeCount,
+                onNavigateToOnBoarding = {
+                    navController.navigate(CakkDestination.OnBoarding.route) {
+                        popUpTo(CakkDestination.Home.route) {
+                            inclusive = true
+                        }
+                    }
+                },
+                onNavigateToDetail = { storeId ->
+                    navController.navigate("${CakkDestination.HomeDetail.route}/$storeId")
+                }
+            )
         }
 
         composable(

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -26,8 +26,8 @@ fun CakkNavigationGraph(navController: NavHostController) {
             route = CakkDestination.Home.routeWithArgs,
             arguments = CakkDestination.Home.arguments
         ) { navBackStackEntry ->
-            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.districtsArgs)
-            val storeCount = navBackStackEntry.arguments?.getInt(CakkDestination.Home.storeCountArgs)
+            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.DISTRICTS_INFO)
+            val storeCount = navBackStackEntry.arguments?.getInt(CakkDestination.Home.STORE_COUNT)
             if (districts != null && storeCount != null) {
                 HomeScreen(navHostController = navController, districts = districts, storeCount = storeCount)
             }
@@ -37,7 +37,7 @@ fun CakkNavigationGraph(navController: NavHostController) {
             route = CakkDestination.HomeDetail.routeWithArgs,
             arguments = CakkDestination.HomeDetail.arguments
         ) { navBackStackEntry ->
-            val storeId = navBackStackEntry.arguments?.getInt(CakkDestination.HomeDetail.storeIdArg)
+            val storeId = navBackStackEntry.arguments?.getInt(CakkDestination.HomeDetail.STORE_ID)
             storeId?.let { HomeDetailScreen(navHostController = navController, storeId = it) }
         }
 

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -26,8 +26,11 @@ fun CakkNavigationGraph(navController: NavHostController) {
             route = CakkDestination.Home.routeWithArgs,
             arguments = CakkDestination.Home.arguments
         ) { navBackStackEntry ->
-            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.districtsArgs) ?: CakkDestination.Home.defaultValue
-            HomeScreen(navHostController = navController, districts = districts)
+            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.districtsArgs)
+            val storeCount = navBackStackEntry.arguments?.getInt(CakkDestination.Home.storeCountArgs)
+            if (districts != null && storeCount != null) {
+                HomeScreen(navHostController = navController, districts = districts, storeCount = storeCount)
+            }
         }
 
         composable(

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -60,7 +60,17 @@ fun CakkNavigationGraph(navController: NavHostController) {
         }
 
         composable(route = CakkDestination.OnBoarding.route) {
-            OnBoardingScreen(navHostController = navController)
+            OnBoardingScreen { districts, storeCount ->
+                navController.navigate(
+                    CakkDestination.Home.route + "?" +
+                        "${CakkDestination.Home.DISTRICTS_INFO}=$districts" + "&" +
+                        "${CakkDestination.Home.STORE_COUNT}=$storeCount"
+                ) {
+                    popUpTo(CakkDestination.OnBoarding.route) {
+                        inclusive = true
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -28,9 +28,7 @@ fun CakkNavigationGraph(navController: NavHostController) {
         ) { navBackStackEntry ->
             val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.DISTRICTS_INFO)
             val storeCount = navBackStackEntry.arguments?.getInt(CakkDestination.Home.STORE_COUNT)
-            if (districts != null && storeCount != null) {
-                HomeScreen(navHostController = navController, districts = districts, storeCount = storeCount)
-            }
+            HomeScreen(navHostController = navController, districtsArg = districts, storeCountArg = storeCount)
         }
 
         composable(

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -26,7 +26,7 @@ fun CakkNavigationGraph(navController: NavHostController) {
             route = CakkDestination.Home.routeWithArgs,
             arguments = CakkDestination.Home.arguments
         ) { navBackStackEntry ->
-            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.districtsArgs)
+            val districts = navBackStackEntry.arguments?.getString(CakkDestination.Home.districtsArgs) ?: CakkDestination.Home.defaultValue
             HomeScreen(navHostController = navController, districts = districts)
         }
 

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -69,6 +69,7 @@ fun CakkNavigationGraph(navController: NavHostController) {
                     popUpTo(CakkDestination.OnBoarding.route) {
                         inclusive = true
                     }
+                    launchSingleTop = true
                 }
             }
         }

--- a/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
+++ b/app/src/main/java/org/prography/cakk/navigation/CakkNavigationGraph.kt
@@ -19,7 +19,13 @@ fun CakkNavigationGraph(navController: NavHostController) {
         startDestination = CakkDestination.Splash.route,
     ) {
         composable(route = CakkDestination.Splash.route) {
-            SplashScreen(navHostController = navController)
+            SplashScreen {
+                navController.navigate(CakkDestination.Home.route) {
+                    popUpTo(CakkDestination.Splash.route) {
+                        inclusive = true
+                    }
+                }
+            }
         }
 
         composable(

--- a/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
+++ b/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
@@ -7,7 +7,16 @@ sealed class CakkDestination(
     val route: String,
 ) {
     object Splash : CakkDestination(route = SPLASH)
-    object Home : CakkDestination(route = HOME)
+    object Home : CakkDestination(route = HOME) {
+        const val districtsArgs = "districts"
+        val routeWithArgs = "$route?$districtsArgs={$districtsArgs}"
+        val arguments = listOf(
+            navArgument(districtsArgs) {
+                type = NavType.StringType
+                defaultValue = ""
+            }
+        )
+    }
 
     object HomeDetail : CakkDestination(route = HOME_DETAIL) {
         const val storeIdArg = "store_id"

--- a/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
+++ b/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
@@ -9,11 +9,12 @@ sealed class CakkDestination(
     object Splash : CakkDestination(route = SPLASH)
     object Home : CakkDestination(route = HOME) {
         const val districtsArgs = "districts"
+        const val defaultValue = ""
         val routeWithArgs = "$route?$districtsArgs={$districtsArgs}"
         val arguments = listOf(
             navArgument(districtsArgs) {
                 type = NavType.StringType
-                defaultValue = ""
+                defaultValue = Home.defaultValue
             }
         )
     }

--- a/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
+++ b/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
@@ -8,15 +8,15 @@ sealed class CakkDestination(
 ) {
     object Splash : CakkDestination(route = SPLASH)
     object Home : CakkDestination(route = HOME) {
-        const val districtsArgs = "districts"
-        const val storeCountArgs = "storeCount"
-        val routeWithArgs = "$route?$districtsArgs={$districtsArgs}&$storeCountArgs={$storeCountArgs}"
+        const val DISTRICTS_INFO = "DISTRICTS_INFO"
+        const val STORE_COUNT = "STORE_COUNT"
+        val routeWithArgs = "$route?$DISTRICTS_INFO={$DISTRICTS_INFO}&$STORE_COUNT={$STORE_COUNT}"
         val arguments = listOf(
-            navArgument(districtsArgs) {
+            navArgument(DISTRICTS_INFO) {
                 type = NavType.StringType
                 defaultValue = ""
             },
-            navArgument(storeCountArgs) {
+            navArgument(STORE_COUNT) {
                 type = NavType.IntType
                 defaultValue = -1
             }
@@ -24,10 +24,10 @@ sealed class CakkDestination(
     }
 
     object HomeDetail : CakkDestination(route = HOME_DETAIL) {
-        const val storeIdArg = "store_id"
-        val routeWithArgs = "$route/{$storeIdArg}"
+        const val STORE_ID = "STORE_ID"
+        val routeWithArgs = "$route/{$STORE_ID}"
         val arguments = listOf(
-            navArgument(storeIdArg) { type = NavType.IntType }
+            navArgument(STORE_ID) { type = NavType.IntType }
         )
     }
 

--- a/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
+++ b/core/utility/src/main/java/org/prography/utility/navigation/destination/CakkDestination.kt
@@ -9,12 +9,16 @@ sealed class CakkDestination(
     object Splash : CakkDestination(route = SPLASH)
     object Home : CakkDestination(route = HOME) {
         const val districtsArgs = "districts"
-        const val defaultValue = ""
-        val routeWithArgs = "$route?$districtsArgs={$districtsArgs}"
+        const val storeCountArgs = "storeCount"
+        val routeWithArgs = "$route?$districtsArgs={$districtsArgs}&$storeCountArgs={$storeCountArgs}"
         val arguments = listOf(
             navArgument(districtsArgs) {
                 type = NavType.StringType
-                defaultValue = Home.defaultValue
+                defaultValue = ""
+            },
+            navArgument(storeCountArgs) {
+                type = NavType.IntType
+                defaultValue = -1
             }
         )
     }

--- a/data/src/main/java/org/prography/cakk/data/api/model/enums/DistrictType.kt
+++ b/data/src/main/java/org/prography/cakk/data/api/model/enums/DistrictType.kt
@@ -26,4 +26,9 @@ enum class DistrictType(val districtKr: String, val groupId: Int) {
     GANGNAM("강남", 7),
     GANGDONG("강동", 8),
     SONGPA("송파", 8),
+    ;
+
+    companion object {
+        fun getName(district: String) = valueOf(district)
+    }
 }

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -61,9 +61,12 @@ var fusedLocationClient: FusedLocationProviderClient? = null
 fun HomeScreen(
     navHostController: NavHostController = rememberNavController(),
     homeViewModel: HomeViewModel = hiltViewModel(),
-    districts: String,
-    storeCount: Int,
+    districtsArg: String?,
+    storeCountArg: Int?,
 ) {
+    val districts = districtsArg ?: throw IllegalArgumentException()
+    val storeCount = storeCountArg ?: throw IllegalArgumentException()
+
     val permissions = arrayOf(
         Manifest.permission.ACCESS_COARSE_LOCATION,
         Manifest.permission.ACCESS_FINE_LOCATION,

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -108,7 +108,7 @@ fun HomeScreen(
         homeViewModel,
         settingResultRequest,
         storeList = homeState.value.storeModels,
-        districts = if (districts.isNotEmpty()) districts.split(" ").map { DistrictType.valueOf(it) } else listOf(),
+        districts = if (districts.isNotEmpty()) districts.split(" ").map { DistrictType.getName(it) } else listOf(),
         storeCount = if (storeCount >= 0) storeCount else homeState.value.storeModels.size,
         bottomExpandedType = homeState.value.lastExpandedType,
         navigateToOnBoarding = {

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -147,6 +147,7 @@ fun HomeScreen(
         navHostController,
         settingResultRequest,
         storeList = storeList,
+        districts = if (districts.isNotEmpty()) districts.split(" ").map { DistrictType.valueOf(it) } else listOf(),
         screenHeight = screenHeight,
         statusBarHeight = statusBarHeight,
         navigateToOnBoarding = {
@@ -168,6 +169,7 @@ private fun BottomSheet(
     navHostController: NavHostController,
     settingResultRequest: ManagedActivityResultLauncher<IntentSenderRequest, ActivityResult>,
     storeList: List<StoreModel>,
+    districts: List<DistrictType>,
     screenHeight: Int,
     statusBarHeight: Int,
     navigateToOnBoarding: () -> Unit,
@@ -221,7 +223,7 @@ private fun BottomSheet(
                     }
                     .background(White),
             ) {
-                BottomSheetContent(storeList, navigateToOnBoarding, navigateToDetail)
+                BottomSheetContent(storeList, districts, navigateToOnBoarding, navigateToDetail)
             }
         },
         sheetPeekHeight = height,
@@ -270,6 +272,7 @@ private fun SearchArea(
 @Composable
 private fun BottomSheetContent(
     storeList: List<StoreModel>,
+    districts: List<DistrictType>,
     navigateToOnBoarding: () -> Unit,
     navigateToDetail: (Int) -> Unit,
 ) {
@@ -277,7 +280,12 @@ private fun BottomSheetContent(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        BottomSheetTop(modifier = Modifier.align(Alignment.Start), navigateToOnBoarding)
+        BottomSheetTop(
+            modifier = Modifier.align(Alignment.Start),
+            title = if (districts.isNotEmpty()) districts.joinToString { it.districtKr } else "현재 위치",
+            store_count = storeList.size,
+            navigateToOnBoarding
+        )
 
         LazyColumn(
             modifier = Modifier.padding(top = 22.dp),
@@ -377,7 +385,12 @@ private fun StoreTags(store: StoreModel) {
 }
 
 @Composable
-private fun BottomSheetTop(modifier: Modifier, navigateToOnBoarding: () -> Unit) {
+private fun BottomSheetTop(
+    modifier: Modifier,
+    title: String,
+    store_count: Int,
+    navigateToOnBoarding: () -> Unit,
+) {
     Image(
         painter = painterResource(id = R.drawable.ic_line),
         contentDescription = null,
@@ -392,7 +405,7 @@ private fun BottomSheetTop(modifier: Modifier, navigateToOnBoarding: () -> Unit)
     ) {
         Column {
             Text(
-                text = "은평, 마포, 서대문",
+                text = title,
                 fontFamily = pretendard,
                 fontWeight = FontWeight.Bold,
                 fontSize = 18.dp.toSp(),
@@ -401,7 +414,7 @@ private fun BottomSheetTop(modifier: Modifier, navigateToOnBoarding: () -> Unit)
                     .padding(top = 30.dp)
             )
             Text(
-                text = "24개의 케이크샵",
+                text = "${store_count}개의 케이크샵",
                 fontFamily = pretendard,
                 fontWeight = FontWeight.Normal,
                 fontSize = 14.dp.toSp(),

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -84,6 +84,7 @@ fun HomeScreen(
     navHostController: NavHostController = rememberNavController(),
     homeViewModel: HomeViewModel = hiltViewModel(),
     districts: String,
+    storeCount: Int,
 ) {
     val context = LocalContext.current
 
@@ -148,6 +149,7 @@ fun HomeScreen(
         settingResultRequest,
         storeList = storeList,
         districts = if (districts.isNotEmpty()) districts.split(" ").map { DistrictType.valueOf(it) } else listOf(),
+        storeCount = if (storeCount >= 0) storeCount else storeList.size,
         screenHeight = screenHeight,
         statusBarHeight = statusBarHeight,
         navigateToOnBoarding = {
@@ -170,6 +172,7 @@ private fun BottomSheet(
     settingResultRequest: ManagedActivityResultLauncher<IntentSenderRequest, ActivityResult>,
     storeList: List<StoreModel>,
     districts: List<DistrictType>,
+    storeCount: Int,
     screenHeight: Int,
     statusBarHeight: Int,
     navigateToOnBoarding: () -> Unit,
@@ -223,7 +226,7 @@ private fun BottomSheet(
                     }
                     .background(White),
             ) {
-                BottomSheetContent(storeList, districts, navigateToOnBoarding, navigateToDetail)
+                BottomSheetContent(storeList, districts, storeCount, navigateToOnBoarding, navigateToDetail)
             }
         },
         sheetPeekHeight = height,
@@ -273,6 +276,7 @@ private fun SearchArea(
 private fun BottomSheetContent(
     storeList: List<StoreModel>,
     districts: List<DistrictType>,
+    storeCount: Int,
     navigateToOnBoarding: () -> Unit,
     navigateToDetail: (Int) -> Unit,
 ) {
@@ -283,7 +287,7 @@ private fun BottomSheetContent(
         BottomSheetTop(
             modifier = Modifier.align(Alignment.Start),
             title = if (districts.isNotEmpty()) districts.joinToString { it.districtKr } else "현재 위치",
-            store_count = storeList.size,
+            storeCount = storeCount,
             navigateToOnBoarding
         )
 
@@ -388,7 +392,7 @@ private fun StoreTags(store: StoreModel) {
 private fun BottomSheetTop(
     modifier: Modifier,
     title: String,
-    store_count: Int,
+    storeCount: Int,
     navigateToOnBoarding: () -> Unit,
 ) {
     Image(
@@ -414,7 +418,7 @@ private fun BottomSheetTop(
                     .padding(top = 30.dp)
             )
             Text(
-                text = "${store_count}개의 케이크샵",
+                text = "${storeCount}개의 케이크샵",
                 fontFamily = pretendard,
                 fontWeight = FontWeight.Normal,
                 fontSize = 14.dp.toSp(),

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -73,6 +73,7 @@ enum class ExpandedType {
 fun HomeScreen(
     navHostController: NavHostController = rememberNavController(),
     homeViewModel: HomeViewModel = hiltViewModel(),
+    districts: String?,
 ) {
     LocationPermission(navHostController)
 

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -63,6 +63,8 @@ fun HomeScreen(
     homeViewModel: HomeViewModel = hiltViewModel(),
     districtsArg: String?,
     storeCountArg: Int?,
+    onNavigateToOnBoarding: () -> Unit,
+    onNavigateToDetail: (Int) -> Unit,
 ) {
     val districts = districtsArg ?: throw IllegalArgumentException()
     val storeCount = storeCountArg ?: throw IllegalArgumentException()
@@ -92,11 +94,7 @@ fun HomeScreen(
             Timber.i("권한이 동의되었습니다.")
         } else {
             Timber.i("권한이 거부되었습니다.")
-            navHostController.navigate(CakkDestination.OnBoarding.route) {
-                popUpTo(CakkDestination.Home.route) {
-                    inclusive = true
-                }
-            }
+            onNavigateToOnBoarding()
         }
     }
 
@@ -111,16 +109,8 @@ fun HomeScreen(
         districts = if (districts.isNotEmpty()) districts.split(" ").map { DistrictType.getName(it) } else listOf(),
         storeCount = if (storeCount >= 0) storeCount else homeState.value.storeModels.size,
         bottomExpandedType = homeState.value.lastExpandedType,
-        navigateToOnBoarding = {
-            navHostController.navigate(CakkDestination.OnBoarding.route) {
-                popUpTo(CakkDestination.Home.route) {
-                    inclusive = true
-                }
-            }
-        },
-        navigateToDetail = { storeId ->
-            navHostController.navigate("${CakkDestination.HomeDetail.route}/$storeId")
-        }
+        onNavigateToOnBoarding = onNavigateToOnBoarding,
+        onNavigateToDetail = onNavigateToDetail
     )
 
     LaunchedEffect(homeViewModel) {
@@ -145,8 +135,8 @@ private fun BottomSheet(
     districts: List<DistrictType>,
     storeCount: Int,
     bottomExpandedType: ExpandedType,
-    navigateToOnBoarding: () -> Unit,
-    navigateToDetail: (Int) -> Unit,
+    onNavigateToOnBoarding: () -> Unit,
+    onNavigateToDetail: (Int) -> Unit,
 ) {
     val context = LocalContext.current
     val screenHeight = LocalConfiguration.current.screenHeightDp
@@ -208,7 +198,13 @@ private fun BottomSheet(
                     }
                     .background(White),
             ) {
-                BottomSheetContent(storeList, districts, storeCount, navigateToOnBoarding, navigateToDetail)
+                BottomSheetContent(
+                    storeList = storeList,
+                    districts = districts,
+                    storeCount = storeCount,
+                    onNavigateToOnBoarding = onNavigateToOnBoarding,
+                    onNavigateToDetail = onNavigateToDetail
+                )
             }
         },
         sheetPeekHeight = height,
@@ -259,8 +255,8 @@ private fun BottomSheetContent(
     storeList: List<StoreModel>,
     districts: List<DistrictType>,
     storeCount: Int,
-    navigateToOnBoarding: () -> Unit,
-    navigateToDetail: (Int) -> Unit,
+    onNavigateToOnBoarding: () -> Unit,
+    onNavigateToDetail: (Int) -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -270,7 +266,7 @@ private fun BottomSheetContent(
             modifier = Modifier.align(Alignment.Start),
             title = if (districts.isNotEmpty()) districts.joinToString { it.districtKr } else "현재 위치",
             storeCount = storeCount,
-            navigateToOnBoarding
+            onNavigateToOnBoarding = onNavigateToOnBoarding
         )
 
         LazyColumn(
@@ -281,7 +277,7 @@ private fun BottomSheetContent(
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth()
-                        .clickable { navigateToDetail(store.id) },
+                        .clickable { onNavigateToDetail(store.id) },
                     shape = RoundedCornerShape(24.dp),
                     color = OldLace
                 ) {
@@ -375,7 +371,7 @@ private fun BottomSheetTop(
     modifier: Modifier,
     title: String,
     storeCount: Int,
-    navigateToOnBoarding: () -> Unit,
+    onNavigateToOnBoarding: () -> Unit,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_line),
@@ -418,9 +414,7 @@ private fun BottomSheetTop(
                 text = stringResource(id = R.string.home_change_location),
                 modifier = Modifier
                     .padding(horizontal = 16.dp, vertical = 12.dp)
-                    .clickable {
-                        navigateToOnBoarding()
-                    },
+                    .clickable { onNavigateToOnBoarding() },
                 fontFamily = pretendard,
                 fontSize = 12.dp.toSp(),
                 color = Magenta,

--- a/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
@@ -8,4 +8,10 @@ sealed class HomeUiAction : BaseAction {
     data class LoadStoreList(val districts: List<String>) : HomeUiAction()
 
     data class LoadedStoreList(val storeModels: List<StoreModel>) : HomeUiAction()
+
+    object BottomSheetExpandFull : HomeUiAction()
+
+    object BottomSheetExpandHalf : HomeUiAction()
+
+    object BottomSheetExpandCollapsed : HomeUiAction()
 }

--- a/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
@@ -1,0 +1,11 @@
+package org.prography.home
+
+import org.prography.base.BaseAction
+
+sealed class HomeUiAction : BaseAction {
+    object Loading : HomeUiAction()
+
+    data class LoadStoreList(val districts: List<String>) : HomeUiAction()
+
+    data class LoadedStoreList(val storeModels: List<StoreModel>) : HomeUiAction()
+}

--- a/feature/home/src/main/java/org/prography/home/HomeUiSideEffect.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiSideEffect.kt
@@ -1,0 +1,5 @@
+package org.prography.home
+
+import org.prography.base.BaseSideEffect
+
+sealed class HomeUiSideEffect : BaseSideEffect

--- a/feature/home/src/main/java/org/prography/home/HomeUiState.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiState.kt
@@ -1,0 +1,7 @@
+package org.prography.home
+
+import org.prography.base.BaseState
+
+data class HomeUiState(
+    val storeModels: List<StoreModel> = listOf(),
+) : BaseState

--- a/feature/home/src/main/java/org/prography/home/HomeUiState.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiState.kt
@@ -1,7 +1,31 @@
 package org.prography.home
 
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import org.prography.base.BaseState
 
 data class HomeUiState(
     val storeModels: List<StoreModel> = listOf(),
+    val lastExpandedType: ExpandedType = ExpandedType.HALF,
 ) : BaseState
+
+enum class ExpandedType {
+    HALF, FULL, COLLAPSED, MOVING;
+
+    fun getByScreenHeight(type: ExpandedType, screenHeight: Int, statusBarHeight: Int, offsetY: Float): Dp {
+        return when (type) {
+            FULL -> {
+                (screenHeight - statusBarHeight).dp
+            }
+            HALF -> {
+                ((screenHeight / 2.5).toInt()).dp
+            }
+            COLLAPSED -> {
+                53.dp
+            }
+            MOVING -> {
+                offsetY.dp
+            }
+        }
+    }
+}

--- a/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.*
 import org.prography.base.BaseViewModel
 import org.prography.cakk.data.api.model.request.StoreListRequest
 import org.prography.cakk.data.repository.store.StoreRepository
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,7 +28,6 @@ class HomeViewModel @Inject constructor(
 
     @OptIn(FlowPreview::class)
     private fun fetchStoreList(districts: List<String>) {
-        Timber.i("fetchStoreList ${districts.first()}")
         districts.asFlow()
             .flatMapMerge { storeRepository.fetchStoreList(StoreListRequest(it, 1)) }
             .onStart { sendAction(HomeUiAction.Loading) }

--- a/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
@@ -16,6 +16,9 @@ class HomeViewModel @Inject constructor(
     initialState = HomeUiState()
 ) {
     override fun reduceState(currentState: HomeUiState, action: HomeUiAction): HomeUiState = when (action) {
+        HomeUiAction.BottomSheetExpandFull -> currentState.copy(lastExpandedType = ExpandedType.FULL)
+        HomeUiAction.BottomSheetExpandHalf -> currentState.copy(lastExpandedType = ExpandedType.HALF)
+        HomeUiAction.BottomSheetExpandCollapsed -> currentState.copy(lastExpandedType = ExpandedType.COLLAPSED)
         HomeUiAction.Loading -> currentState
         is HomeUiAction.LoadStoreList -> {
             fetchStoreList(action.districts)
@@ -28,7 +31,7 @@ class HomeViewModel @Inject constructor(
 
     @OptIn(FlowPreview::class)
     private fun fetchStoreList(districts: List<String>) {
-        districts.asFlow()
+        districts.sorted().asFlow()
             .flatMapMerge { storeRepository.fetchStoreList(StoreListRequest(it, 1)) }
             .onStart { sendAction(HomeUiAction.Loading) }
             .onEach { sendAction(HomeUiAction.LoadedStoreList(it.toModel())) }

--- a/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
@@ -1,22 +1,39 @@
 package org.prography.home
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+import org.prography.base.BaseViewModel
 import org.prography.cakk.data.api.model.request.StoreListRequest
 import org.prography.cakk.data.repository.store.StoreRepository
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    storeRepository: StoreRepository,
-) : ViewModel() {
+    private val storeRepository: StoreRepository,
+) : BaseViewModel<HomeUiAction, HomeUiState, HomeUiSideEffect>(
+    initialState = HomeUiState()
+) {
+    override fun reduceState(currentState: HomeUiState, action: HomeUiAction): HomeUiState = when (action) {
+        HomeUiAction.Loading -> currentState
+        is HomeUiAction.LoadStoreList -> {
+            fetchStoreList(action.districts)
+            currentState
+        }
+        is HomeUiAction.LoadedStoreList -> {
+            currentState.copy(storeModels = currentState.storeModels + action.storeModels)
+        }
+    }
 
-    val stores = storeRepository.fetchStoreList(StoreListRequest("JONGNO", 1)).stateIn(
-        initialValue = listOf(),
-        started = SharingStarted.WhileSubscribed(),
-        scope = viewModelScope
-    )
+    @OptIn(FlowPreview::class)
+    private fun fetchStoreList(districts: List<String>) {
+        Timber.i("fetchStoreList ${districts.first()}")
+        districts.asFlow()
+            .flatMapMerge { storeRepository.fetchStoreList(StoreListRequest(it, 1)) }
+            .onStart { sendAction(HomeUiAction.Loading) }
+            .onEach { sendAction(HomeUiAction.LoadedStoreList(it.toModel())) }
+            .launchIn(viewModelScope)
+    }
 }

--- a/feature/home/src/main/java/org/prography/home/StoreModel.kt
+++ b/feature/home/src/main/java/org/prography/home/StoreModel.kt
@@ -1,0 +1,31 @@
+package org.prography.home
+
+import org.prography.cakk.data.api.model.response.StoreListResponse
+
+data class StoreModel(
+    val id: Int = 0,
+    val createdAt: String = "",
+    val modifiedAt: String = "",
+    val name: String = "",
+    val city: String = "",
+    val district: String = "",
+    val location: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val storeTypes: List<String> = listOf(),
+)
+
+fun StoreListResponse.toModel() = StoreModel(
+    id = id,
+    createdAt = createdAt,
+    modifiedAt = modifiedAt,
+    name = name,
+    city = city,
+    district = district,
+    location = location,
+    latitude = latitude,
+    longitude = longitude,
+    storeTypes = storeTypes
+)
+
+fun List<StoreListResponse>.toModel() = map { it.toModel() }

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -33,7 +33,7 @@ import org.prography.utility.navigation.destination.CakkDestination
 @Composable
 fun OnBoardingScreen(
     navHostController: NavHostController = rememberNavController(),
-    onBoardingViewModel: OnBoardingViewModel = hiltViewModel()
+    onBoardingViewModel: OnBoardingViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(true) {
         onBoardingViewModel.sendAction(OnBoardingAction.LoadDistrictList)
@@ -75,16 +75,18 @@ fun OnBoardingScreen(
             }
         }
 
-        items(districtList) {
+        items(districtList) { districtGroup ->
             OnBoardingRegionItem(
                 modifier = Modifier
                     .padding(2.dp)
                     .aspectRatio(17 / 12f),
-                region = it.districts.joinToString(separator = " ") { it.district.districtKr },
-                count = it.count,
-                color = it.districts.first().district.toColor(),
+                region = districtGroup.districts.joinToString(separator = " ") { it.district.districtKr },
+                count = districtGroup.count,
+                color = districtGroup.districts.first().district.toColor(),
                 onClick = {
-                    navHostController.navigate(CakkDestination.Home.route) {
+                    val districtJoinString = districtGroup.districts.joinToString(" ") { it.district.name }
+
+                    navHostController.navigate("${CakkDestination.Home.route}?${CakkDestination.Home.districtsArgs}=$districtJoinString") {
                         popUpTo(CakkDestination.OnBoarding.route) {
                             inclusive = false
                         }
@@ -101,7 +103,7 @@ private fun OnBoardingRegionItem(
     region: String,
     count: Int,
     color: Color,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Box(
         modifier = modifier

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -29,13 +29,13 @@ import org.prography.designsystem.ui.theme.White
 import org.prography.designsystem.ui.theme.pretendard
 import org.prography.utility.extensions.toSp
 import org.prography.utility.navigation.destination.CakkDestination
-import org.prography.utility.navigation.destination.CakkDestination.Home.districtsArgs
-import org.prography.utility.navigation.destination.CakkDestination.Home.storeCountArgs
+import org.prography.utility.navigation.destination.CakkDestination.Home.DISTRICTS_INFO
+import org.prography.utility.navigation.destination.CakkDestination.Home.STORE_COUNT
 
 @Composable
 fun OnBoardingScreen(
     navHostController: NavHostController = rememberNavController(),
-    onBoardingViewModel: OnBoardingViewModel = hiltViewModel()
+    onBoardingViewModel: OnBoardingViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(true) {
         onBoardingViewModel.sendAction(OnBoardingAction.LoadDistrictList)
@@ -88,7 +88,7 @@ fun OnBoardingScreen(
                 onClick = {
                     val districtJoinString = districtGroup.districts.joinToString(" ") { it.district.name }
                     navHostController.navigate(
-                        "${CakkDestination.Home.route}?$districtsArgs=$districtJoinString&$storeCountArgs=${districtGroup.count}"
+                        "${CakkDestination.Home.route}?$DISTRICTS_INFO=$districtJoinString&$STORE_COUNT=${districtGroup.count}"
                     ) {
                         popUpTo(CakkDestination.OnBoarding.route) {
                             inclusive = false
@@ -106,7 +106,7 @@ private fun OnBoardingRegionItem(
     region: String,
     count: Int,
     color: Color,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Box(
         modifier = modifier

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -29,6 +29,8 @@ import org.prography.designsystem.ui.theme.White
 import org.prography.designsystem.ui.theme.pretendard
 import org.prography.utility.extensions.toSp
 import org.prography.utility.navigation.destination.CakkDestination
+import org.prography.utility.navigation.destination.CakkDestination.Home.districtsArgs
+import org.prography.utility.navigation.destination.CakkDestination.Home.storeCountArgs
 
 @Composable
 fun OnBoardingScreen(
@@ -85,8 +87,9 @@ fun OnBoardingScreen(
                 color = districtGroup.districts.first().district.toColor(),
                 onClick = {
                     val districtJoinString = districtGroup.districts.joinToString(" ") { it.district.name }
-
-                    navHostController.navigate("${CakkDestination.Home.route}?${CakkDestination.Home.districtsArgs}=$districtJoinString") {
+                    navHostController.navigate(
+                        "${CakkDestination.Home.route}?$districtsArgs=$districtJoinString&$storeCountArgs=${districtGroup.count}"
+                    ) {
                         popUpTo(CakkDestination.OnBoarding.route) {
                             inclusive = false
                         }

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -21,21 +21,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import org.prography.designsystem.extensions.toColor
 import org.prography.designsystem.ui.theme.Black
 import org.prography.designsystem.ui.theme.White
 import org.prography.designsystem.ui.theme.pretendard
 import org.prography.utility.extensions.toSp
-import org.prography.utility.navigation.destination.CakkDestination
-import org.prography.utility.navigation.destination.CakkDestination.Home.DISTRICTS_INFO
-import org.prography.utility.navigation.destination.CakkDestination.Home.STORE_COUNT
 
 @Composable
 fun OnBoardingScreen(
-    navHostController: NavHostController = rememberNavController(),
     onBoardingViewModel: OnBoardingViewModel = hiltViewModel(),
+    onNavigateHome: (String, Int) -> Unit,
 ) {
     LaunchedEffect(true) {
         onBoardingViewModel.sendAction(OnBoardingAction.LoadDistrictList)
@@ -87,13 +82,7 @@ fun OnBoardingScreen(
                 color = districtGroup.districts.first().district.toColor(),
                 onClick = {
                     val districtJoinString = districtGroup.districts.joinToString(" ") { it.district.name }
-                    navHostController.navigate(
-                        "${CakkDestination.Home.route}?$DISTRICTS_INFO=$districtJoinString&$STORE_COUNT=${districtGroup.count}"
-                    ) {
-                        popUpTo(CakkDestination.OnBoarding.route) {
-                            inclusive = false
-                        }
-                    }
+                    onNavigateHome(districtJoinString, districtGroup.count)
                 }
             )
         }

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -30,7 +30,7 @@ import org.prography.utility.extensions.toSp
 @Composable
 fun OnBoardingScreen(
     onBoardingViewModel: OnBoardingViewModel = hiltViewModel(),
-    onNavigateHome: (String, Int) -> Unit,
+    onNavigateHome: (String, Int) -> Unit
 ) {
     LaunchedEffect(true) {
         onBoardingViewModel.sendAction(OnBoardingAction.LoadDistrictList)
@@ -95,7 +95,7 @@ private fun OnBoardingRegionItem(
     region: String,
     count: Int,
     color: Color,
-    onClick: () -> Unit,
+    onClick: () -> Unit
 ) {
     Box(
         modifier = modifier

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -35,7 +35,7 @@ import org.prography.utility.navigation.destination.CakkDestination.Home.storeCo
 @Composable
 fun OnBoardingScreen(
     navHostController: NavHostController = rememberNavController(),
-    onBoardingViewModel: OnBoardingViewModel = hiltViewModel(),
+    onBoardingViewModel: OnBoardingViewModel = hiltViewModel()
 ) {
     LaunchedEffect(true) {
         onBoardingViewModel.sendAction(OnBoardingAction.LoadDistrictList)
@@ -106,7 +106,7 @@ private fun OnBoardingRegionItem(
     region: String,
     count: Int,
     color: Color,
-    onClick: () -> Unit,
+    onClick: () -> Unit
 ) {
     Box(
         modifier = modifier

--- a/feature/splash/src/main/java/org/prography/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/org/prography/splash/SplashScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
@@ -26,10 +24,9 @@ import org.prography.designsystem.ui.theme.Light_Cobalt_Blue
 import org.prography.designsystem.ui.theme.White
 import org.prography.designsystem.ui.theme.pretendard
 import org.prography.utility.extensions.toSp
-import org.prography.utility.navigation.destination.CakkDestination
 
 @Composable
-fun SplashScreen(navHostController: NavHostController = rememberNavController()) {
+fun SplashScreen(onNavigateHome: () -> Unit) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
@@ -49,13 +46,7 @@ fun SplashScreen(navHostController: NavHostController = rememberNavController())
             }
         }
 
-        if (logoAnimationState.isAtEnd && logoAnimationState.isPlaying) {
-            navHostController.navigate(CakkDestination.Home.route) {
-                popUpTo(CakkDestination.Splash.route) {
-                    inclusive = true
-                }
-            }
-        }
+        if (logoAnimationState.isAtEnd && logoAnimationState.isPlaying) onNavigateHome()
 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Image(
@@ -81,5 +72,6 @@ fun SplashScreen(navHostController: NavHostController = rememberNavController())
 @Preview
 @Composable
 private fun SplashScreenPreview() {
-    SplashScreen()
+    SplashScreen {
+    }
 }


### PR DESCRIPTION
## Related issue
- closed #31 

## Work Description
홈 지도 화면 MVI 아키텍처 적용하고 액션 이벤트 정의
또한, 마지막 바텀 시트 상태도 ViewModel에서 관리하여 상세 정보에서 다시 돌아와도 상태 유지

## Screenshot (선택)

## Uncompleted Tasks
- [x] 홈 화면 MVI 아키텍처 적용
- [x] 온보딩 화면에서 지역 클릭 시 근방 케이크샵 노출 로직 수정
- [x]  케이크샵 상세 화면에서 뒤로 가기 클릭 시 이전 상태 유지
