### PR TITLE
[Feat] 케이크 샵 상세 화면 블로그 리뷰 API 연동

### DIFF
--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="home_detail_address_copy">주소복사</string>
     <string name="home_detail_opening">영업중</string>
     <string name="home_detail_blog_review">블로그 리뷰</string>
+    <string name="home_detail_blog_review_more">블로그 리뷰 더 보기</string>
 </resources>

--- a/core/network/src/main/java/org/prography/network/CakkService.kt
+++ b/core/network/src/main/java/org/prography/network/CakkService.kt
@@ -7,6 +7,7 @@ object CakkService {
         const val STORE_LIST = "api/store/list"
         const val STORE_DETAIL = "api/store"
         const val DISTRICT_LIST = "api/store/district/count"
+        const val STORE_BLOG = "blog"
     }
 
     object Parameter {

--- a/core/network/src/main/java/org/prography/network/api/dto/response/BlogPostResponse.kt
+++ b/core/network/src/main/java/org/prography/network/api/dto/response/BlogPostResponse.kt
@@ -1,0 +1,22 @@
+package org.prography.network.api.dto.response
+
+import org.prography.domain.model.store.BlogPostModel
+
+@kotlinx.serialization.Serializable
+data class BlogPostResponse(
+    val title: String,
+    val link: String,
+    val description: String,
+    val bloggername: String,
+    val bloggerlink: String,
+    val postdate: String
+) {
+    fun toModel() = BlogPostModel(
+        title = title,
+        link = link,
+        description = description,
+        bloggername = bloggername,
+        bloggerlink = bloggerlink,
+        postdate = postdate
+    )
+}

--- a/core/network/src/main/java/org/prography/network/api/dto/response/StoreBlogResponse.kt
+++ b/core/network/src/main/java/org/prography/network/api/dto/response/StoreBlogResponse.kt
@@ -1,0 +1,12 @@
+package org.prography.network.api.dto.response
+
+import org.prography.domain.model.store.StoreBlogModel
+
+@kotlinx.serialization.Serializable
+data class StoreBlogResponse(
+    val blogPosts: List<BlogPostResponse>
+) {
+    fun toModel() = StoreBlogModel(
+        blogPosts = blogPosts.map { it.toModel() }
+    )
+}

--- a/data/src/main/java/org/prography/cakk/data/datasource/StoreRemoteSource.kt
+++ b/data/src/main/java/org/prography/cakk/data/datasource/StoreRemoteSource.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.prography.network.CakkService
+import org.prography.network.api.dto.response.StoreBlogResponse
 import org.prography.network.api.dto.response.StoreDetailResponse
 import org.prography.network.api.dto.response.StoreResponse
 import javax.inject.Inject
@@ -12,10 +13,7 @@ import javax.inject.Inject
 class StoreRemoteSource @Inject constructor(
     private val httpClient: HttpClient
 ) {
-    fun fetchStoreList(
-        district: String,
-        page: Int
-    ): Flow<List<StoreResponse>> = flow {
+    fun fetchStoreList(district: String, page: Int): Flow<List<StoreResponse>> = flow {
         emit(
             httpClient.get {
                 url("${CakkService.BASE_URL}${CakkService.Endpoint.STORE_LIST}")
@@ -29,6 +27,14 @@ class StoreRemoteSource @Inject constructor(
         emit(
             httpClient.get {
                 url("${CakkService.BASE_URL}${CakkService.Endpoint.STORE_DETAIL}/$storeId")
+            }
+        )
+    }
+
+    fun fetchStoreBlog(storeId: Int): Flow<StoreBlogResponse> = flow {
+        emit(
+            httpClient.get {
+                url("${CakkService.BASE_URL}${CakkService.Endpoint.STORE_DETAIL}/$storeId/${CakkService.Endpoint.STORE_BLOG}")
             }
         )
     }

--- a/data/src/main/java/org/prography/cakk/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/org/prography/cakk/data/repository/StoreRepositoryImpl.kt
@@ -3,6 +3,7 @@ package org.prography.cakk.data.repository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.prography.cakk.data.datasource.StoreRemoteSource
+import org.prography.domain.model.store.StoreBlogModel
 import org.prography.domain.model.store.StoreDetailModel
 import org.prography.domain.model.store.StoreModel
 import org.prography.domain.repository.StoreRepository
@@ -13,12 +14,12 @@ class StoreRepositoryImpl @Inject constructor(
     private val storeRemoteSource: StoreRemoteSource
 ) : StoreRepository {
 
-    override fun fetchStoreList(
-        district: String,
-        page: Int
-    ): Flow<List<StoreModel>> =
+    override fun fetchStoreList(district: String, page: Int): Flow<List<StoreModel>> =
         storeRemoteSource.fetchStoreList(district, page).map { it.toModel() }
 
     override fun fetchDetailStore(storeId: Int): Flow<StoreDetailModel> =
         storeRemoteSource.fetchDetailStore(storeId).map { it.toModel() }
+
+    override fun fetchStoreBlog(storeId: Int): Flow<StoreBlogModel> =
+        storeRemoteSource.fetchStoreBlog(storeId).map { it.toModel() }
 }

--- a/domain/src/main/java/org/prography/domain/model/store/BlogPostModel.kt
+++ b/domain/src/main/java/org/prography/domain/model/store/BlogPostModel.kt
@@ -1,0 +1,10 @@
+package org.prography.domain.model.store
+
+data class BlogPostModel(
+    val title: String,
+    val link: String,
+    val description: String,
+    val bloggername: String,
+    val bloggerlink: String,
+    val postdate: String
+)

--- a/domain/src/main/java/org/prography/domain/model/store/StoreBlogModel.kt
+++ b/domain/src/main/java/org/prography/domain/model/store/StoreBlogModel.kt
@@ -1,0 +1,5 @@
+package org.prography.domain.model.store
+
+data class StoreBlogModel(
+    val blogPosts: List<BlogPostModel> = listOf()
+)

--- a/domain/src/main/java/org/prography/domain/repository/StoreRepository.kt
+++ b/domain/src/main/java/org/prography/domain/repository/StoreRepository.kt
@@ -1,15 +1,14 @@
 package org.prography.domain.repository
 
 import kotlinx.coroutines.flow.Flow
+import org.prography.domain.model.store.StoreBlogModel
 import org.prography.domain.model.store.StoreDetailModel
 import org.prography.domain.model.store.StoreModel
 
 interface StoreRepository {
-
-    fun fetchStoreList(
-        district: String,
-        page: Int
-    ): Flow<List<StoreModel>>
+    fun fetchStoreList(district: String, page: Int): Flow<List<StoreModel>>
 
     fun fetchDetailStore(storeId: Int): Flow<StoreDetailModel>
+
+    fun fetchStoreBlog(storeId: Int): Flow<StoreBlogModel>
 }

--- a/feature/home/src/main/java/org/prography/home/HomeUiSideEffect.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiSideEffect.kt
@@ -1,5 +1,0 @@
-package org.prography.home
-
-import org.prography.base.BaseSideEffect
-
-sealed class HomeUiSideEffect : BaseSideEffect

--- a/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val storeRepository: StoreRepository,
-) : BaseViewModel<HomeUiAction, HomeUiState, HomeUiSideEffect>(
+) : BaseViewModel<HomeUiAction, HomeUiState, Nothing>(
     initialState = HomeUiState()
 ) {
     override fun reduceState(currentState: HomeUiState, action: HomeUiAction): HomeUiState = when (action) {

--- a/feature/home/src/main/java/org/prography/home/detail/BlogReviewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/BlogReviewModel.kt
@@ -1,8 +1,0 @@
-package org.prography.home.detail
-
-data class BlogReviewModel(
-    val name: String,
-    val date: String,
-    val title: String,
-    val description: String,
-)

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailAction.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailAction.kt
@@ -1,10 +1,13 @@
 package org.prography.home.detail
 
 import org.prography.base.BaseAction
+import org.prography.domain.model.store.BlogPostModel
 import org.prography.domain.model.store.StoreDetailModel
 
 sealed class HomeDetailAction : BaseAction {
     object Loading : HomeDetailAction()
     data class LoadDetailInfo(val id: Int) : HomeDetailAction()
     data class LoadedDetailInfo(val storeDetailModel: StoreDetailModel) : HomeDetailAction()
+    data class LoadBlogInfos(val id: Int) : HomeDetailAction()
+    data class LoadedBlogInfos(val blogPosts: List<BlogPostModel>) : HomeDetailAction()
 }

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
@@ -30,7 +30,7 @@ import org.prography.cakk.data.api.model.enums.StoreType
 import org.prography.designsystem.R
 import org.prography.designsystem.mapper.toColor
 import org.prography.designsystem.ui.theme.*
-import org.prography.home.detail.BlogReviewModel
+import org.prography.domain.model.store.BlogPostModel
 import org.prography.home.detail.HomeDetailAction
 import org.prography.home.detail.HomeDetailViewModel
 import org.prography.utility.extensions.toSp
@@ -43,10 +43,12 @@ fun HomeDetailScreen(
 ) {
     LaunchedEffect(storeId) {
         homeDetailViewModel.sendAction(HomeDetailAction.LoadDetailInfo(storeId))
+        homeDetailViewModel.sendAction(HomeDetailAction.LoadBlogInfos(storeId))
     }
 
     val storeDetailState = homeDetailViewModel.state.collectAsStateWithLifecycle()
     val storeDetailModel = storeDetailState.value.storeDetailModel
+    val storeBlogPosts = storeDetailState.value.blogPosts
     val scrollState = rememberScrollState()
 
     Column(
@@ -54,10 +56,9 @@ fun HomeDetailScreen(
             .fillMaxSize()
             .background(White)
     ) {
-        HomeDetailAppbar(
-            title = stringResource(R.string.home_detail_app_bar),
-            onBack = { navHostController.popBackStack() }
-        )
+        HomeDetailAppbar(title = stringResource(R.string.home_detail_app_bar)) {
+            navHostController.popBackStack()
+        }
 
         Column(
             modifier = Modifier
@@ -138,26 +139,7 @@ fun HomeDetailScreen(
                 modifier = Modifier
                     .padding(top = 40.dp, bottom = 60.dp)
                     .padding(horizontal = 16.dp),
-                blogReviews = listOf(
-                    BlogReviewModel(
-                        name = "블로거 이름",
-                        date = "2023.05.01",
-                        title = "제목을 입력해 주세요. 제목은 한 줄까지만 노출 되게 제목을 입력해 주세요. 제목은 한 줄까지만 노출 되게",
-                        description = "블로그 내용을 입력해 주세요. 내용은 최대 3줄까지만 쓰게 하려고 해요. 이 섹션 전체를 눌렀을 때 네이버로 이동할 수 있게 해당 블로그 글 링크 연결을 하면 괜찮지 않을까요? 어떻게 생각...",
-                    ),
-                    BlogReviewModel(
-                        name = "블로거 이름",
-                        date = "2023.05.01",
-                        title = "제목을 입력해 주세요. 제목은 한 줄까지만 노출 되게 제목을 입력해 주세요. 제목은 한 줄까지만 노출 되게",
-                        description = "블로그 내용을 입력해 주세요. 내용은 최대 3줄까지만 쓰게 하려고 해요. 이 섹션 전체를 눌렀을 때 네이버로 이동할 수 있게 해당 블로그 글 링크 연결을 하면 괜찮지 않을까요? 어떻게 생각...",
-                    ),
-                    BlogReviewModel(
-                        name = "블로거 이름",
-                        date = "2023.05.01",
-                        title = "제목을 입력해 주세요. 제목은 한 줄까지만 노출 되게 제목을 입력해 주세요. 제목은 한 줄까지만 노출 되게",
-                        description = "블로그 내용을 입력해 주세요. 내용은 최대 3줄까지만 쓰게 하려고 해요. 이 섹션 전체를 눌렀을 때 네이버로 이동할 수 있게 해당 블로그 글 링크 연결을 하면 괜찮지 않을까요? 어떻게 생각...",
-                    )
-                )
+                blogPosts = storeBlogPosts
             )
         }
     }
@@ -166,7 +148,7 @@ fun HomeDetailScreen(
 @Composable
 private fun HomeDetailBlogRow(
     modifier: Modifier = Modifier,
-    blogReviews: List<BlogReviewModel>,
+    blogPosts: List<BlogPostModel>,
 ) {
     Column(modifier) {
         Text(
@@ -186,12 +168,12 @@ private fun HomeDetailBlogRow(
                 .background(Platinum)
         )
 
-        blogReviews.take(3).forEach { review ->
+        blogPosts.take(3).forEach { blogPost ->
             HomeDetailBlogItem(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 23.dp),
-                blogReview = review
+                blogPost = blogPost
             )
 
             Spacer(
@@ -216,7 +198,7 @@ private fun HomeDetailBlogRow(
             )
         ) {
             Text(
-                text = "블로그 리뷰 더 보기",
+                text = stringResource(R.string.home_detail_blog_review_more),
                 color = Raisin_Black,
                 fontSize = 14.dp.toSp(),
                 fontFamily = pretendard,
@@ -230,12 +212,12 @@ private fun HomeDetailBlogRow(
 @Composable
 private fun HomeDetailBlogItem(
     modifier: Modifier = Modifier,
-    blogReview: BlogReviewModel,
+    blogPost: BlogPostModel,
 ) {
     Column(modifier) {
         Row {
             Text(
-                text = blogReview.name,
+                text = blogPost.bloggername,
                 modifier = Modifier.weight(1f, false),
                 color = Raisin_Black,
                 fontSize = 14.dp.toSp(),
@@ -255,7 +237,7 @@ private fun HomeDetailBlogItem(
             )
 
             Text(
-                text = blogReview.date,
+                text = blogPost.postdate,
                 modifier = Modifier.padding(start = 4.dp),
                 color = Raisin_Black.copy(alpha = 0.6f),
                 fontSize = 14.dp.toSp(),
@@ -265,7 +247,7 @@ private fun HomeDetailBlogItem(
         }
 
         Text(
-            text = blogReview.title,
+            text = blogPost.title,
             modifier = Modifier.padding(top = 16.dp),
             color = Raisin_Black,
             fontSize = 16.dp.toSp(),
@@ -277,7 +259,7 @@ private fun HomeDetailBlogItem(
         )
 
         Text(
-            text = blogReview.description,
+            text = blogPost.description,
             modifier = Modifier.padding(top = 12.dp),
             color = Raisin_Black.copy(alpha = 0.8f),
             fontSize = 14.dp.toSp(),
@@ -345,7 +327,7 @@ private fun HomeDetailInfoRow(
             )
 
             Text(
-                text = "주소 복사",
+                text = stringResource(R.string.home_detail_address_copy),
                 modifier = Modifier.padding(start = 4.dp),
                 color = Raisin_Black,
                 fontSize = 14.dp.toSp(),
@@ -465,9 +447,7 @@ private fun HomeDetailKeywordRow(
 private fun HomeDetailTab(
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier.height(intrinsicSize = IntrinsicSize.Max)
-    ) {
+    Row(modifier = modifier.height(intrinsicSize = IntrinsicSize.Max)) {
         HomeDetailTabItem(
             drawableRes = R.drawable.ic_phone,
             stringRes = R.string.home_detail_phone

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
@@ -1,5 +1,7 @@
 package org.prography.home
 
+import android.content.Intent
+import android.net.Uri
 import android.text.Html
 import android.text.Html.FROM_HTML_OPTION_USE_CSS_COLORS
 import androidx.annotation.DrawableRes
@@ -17,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -219,7 +222,13 @@ private fun HomeDetailBlogItem(
     val year = blogPost.postdate.substring(0, 4)
     val month = blogPost.postdate.substring(4, 6)
     val day = blogPost.postdate.substring(6)
-    Column(modifier) {
+
+    val context = LocalContext.current
+    Column(
+        modifier = modifier.clickable {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(blogPost.link)))
+        }
+    ) {
         Row {
             Text(
                 text = Html.fromHtml(blogPost.bloggername, FROM_HTML_OPTION_USE_CSS_COLORS).toString(),

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
@@ -1,5 +1,7 @@
 package org.prography.home
 
+import android.text.Html
+import android.text.Html.FROM_HTML_OPTION_USE_CSS_COLORS
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.*
@@ -214,10 +216,13 @@ private fun HomeDetailBlogItem(
     modifier: Modifier = Modifier,
     blogPost: BlogPostModel,
 ) {
+    val year = blogPost.postdate.substring(0, 4)
+    val month = blogPost.postdate.substring(4, 6)
+    val day = blogPost.postdate.substring(6)
     Column(modifier) {
         Row {
             Text(
-                text = blogPost.bloggername,
+                text = Html.fromHtml(blogPost.bloggername, FROM_HTML_OPTION_USE_CSS_COLORS).toString(),
                 modifier = Modifier.weight(1f, false),
                 color = Raisin_Black,
                 fontSize = 14.dp.toSp(),
@@ -237,7 +242,7 @@ private fun HomeDetailBlogItem(
             )
 
             Text(
-                text = blogPost.postdate,
+                text = "$year.$month.$day",
                 modifier = Modifier.padding(start = 4.dp),
                 color = Raisin_Black.copy(alpha = 0.6f),
                 fontSize = 14.dp.toSp(),
@@ -247,7 +252,7 @@ private fun HomeDetailBlogItem(
         }
 
         Text(
-            text = blogPost.title,
+            text = Html.fromHtml(blogPost.title, FROM_HTML_OPTION_USE_CSS_COLORS).toString(),
             modifier = Modifier.padding(top = 16.dp),
             color = Raisin_Black,
             fontSize = 16.dp.toSp(),
@@ -259,7 +264,7 @@ private fun HomeDetailBlogItem(
         )
 
         Text(
-            text = blogPost.description,
+            text = Html.fromHtml(blogPost.description, FROM_HTML_OPTION_USE_CSS_COLORS).toString(),
             modifier = Modifier.padding(top = 12.dp),
             color = Raisin_Black.copy(alpha = 0.8f),
             fontSize = 14.dp.toSp(),

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailSideEffect.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailSideEffect.kt
@@ -1,5 +1,0 @@
-package org.prography.home.detail
-
-import org.prography.base.BaseSideEffect
-
-sealed class HomeDetailSideEffect : BaseSideEffect

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailState.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailState.kt
@@ -1,8 +1,10 @@
 package org.prography.home.detail
 
 import org.prography.base.BaseState
+import org.prography.domain.model.store.BlogPostModel
 import org.prography.domain.model.store.StoreDetailModel
 
 data class HomeDetailState(
     val storeDetailModel: StoreDetailModel = StoreDetailModel(),
+    val blogPosts: List<BlogPostModel> = listOf()
 ) : BaseState

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailViewModel.kt
@@ -21,13 +21,29 @@ class HomeDetailViewModel @Inject constructor(
             fetchDetailStore(action.id)
             currentState
         }
-        is HomeDetailAction.LoadedDetailInfo -> currentState.copy(storeDetailModel = action.storeDetailModel)
+        is HomeDetailAction.LoadedDetailInfo -> {
+            currentState.copy(storeDetailModel = action.storeDetailModel)
+        }
+        is HomeDetailAction.LoadBlogInfos -> {
+            fetchStoreBlogInfos(action.id)
+            currentState
+        }
+        is HomeDetailAction.LoadedBlogInfos -> {
+            currentState.copy(blogPosts = action.blogPosts)
+        }
     }
 
     private fun fetchDetailStore(id: Int) {
         storeRepository.fetchDetailStore(id)
             .onStart { sendAction(HomeDetailAction.Loading) }
             .onEach { sendAction(HomeDetailAction.LoadedDetailInfo(it)) }
+            .launchIn(viewModelScope)
+    }
+
+    private fun fetchStoreBlogInfos(id: Int) {
+        storeRepository.fetchStoreBlog(id)
+            .onStart { sendAction(HomeDetailAction.Loading) }
+            .onEach { sendAction(HomeDetailAction.LoadedBlogInfos(it.blogPosts)) }
             .launchIn(viewModelScope)
     }
 }

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailViewModel.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeDetailViewModel @Inject constructor(
     private val storeRepository: StoreRepository,
-) : BaseViewModel<HomeDetailAction, HomeDetailState, HomeDetailSideEffect>(
+) : BaseViewModel<HomeDetailAction, HomeDetailState, Nothing>(
     initialState = HomeDetailState()
 ) {
     override fun reduceState(currentState: HomeDetailState, action: HomeDetailAction): HomeDetailState = when (action) {


### PR DESCRIPTION
## Related issue
- closed #36 

## Work Description
케이크 샵 상세 화면 블로그 리뷰 API 연동

## Screenshot (선택
<img src="https://github.com/Prography-8th-team8/Cakk-AOS/assets/34837583/98dcf519-cb31-441d-8963-4603ec39906c" width=300 height=650/>

## Completed Tasks
- [x]  하드코딩된 블로그 리뷰 정보 삭제
- [x] 케이크샵 별 블로그 리뷰정보 조회 API 추가
