### PR TITLE
[feat] 홈 화면 케이크 리스트 데이터 UI 변경 

### DIFF
--- a/core/base/src/main/java/org/prography/base/BaseViewModel.kt
+++ b/core/base/src/main/java/org/prography/base/BaseViewModel.kt
@@ -17,7 +17,7 @@ abstract class BaseViewModel<ACTION : BaseAction, STATE : BaseState, SE : BaseSi
     private val sideEffectChannel: Channel<SE> = Channel(Channel.UNLIMITED)
     val sideEffect: Flow<SE> = sideEffectChannel.receiveAsFlow()
 
-    fun sendAction(action: ACTION) {
+    protected fun sendAction(action: ACTION) {
         viewModelScope.launch {
             actionChannel.send(action)
         }

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -28,6 +28,9 @@ android {
 dependencies {
     implementation(project(":data"))
     implementation(project(":domain"))
+    implementation(project(":core:utility"))
+
+    implementation(libs.coil.compose)
     implementation(libs.material)
     implementation(libs.bundles.androidx.compose)
 }

--- a/core/designsystem/src/main/java/org/prography/designsystem/component/Store.kt
+++ b/core/designsystem/src/main/java/org/prography/designsystem/component/Store.kt
@@ -1,0 +1,181 @@
+package org.prography.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.prography.designsystem.R
+import org.prography.designsystem.mapper.toColor
+import org.prography.designsystem.ui.theme.Old_Lace
+import org.prography.designsystem.ui.theme.Raisin_Black
+import org.prography.designsystem.ui.theme.pretendard
+import org.prography.domain.model.enums.DistrictType
+import org.prography.domain.model.enums.StoreType
+import org.prography.domain.model.store.StoreModel
+import org.prography.utility.extensions.toSp
+
+@Composable
+fun StoreItemContent(
+    modifier: Modifier = Modifier,
+    storeModel: StoreModel = StoreModel(),
+    onFavoriteClick: () -> Unit = {},
+    onClick: () -> Unit = {}
+) {
+    Surface(
+        modifier = modifier.clickable { onClick() },
+        color = Old_Lace,
+        border = BorderStroke(1.dp, Raisin_Black.copy(0.1f))
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(vertical = 20.dp)
+                .padding(start = 20.dp)
+        ) {
+            StoreItemHeader(
+                storeName = storeModel.name,
+                storeDistrict = storeModel.district,
+                storeLocation = storeModel.location,
+                onClick = onFavoriteClick
+            )
+
+            StoreItemTagRow(
+                modifier = Modifier.padding(top = 12.dp),
+                storeTypes = storeModel.storeTypes
+            )
+
+            StoreItemImageRow(
+                modifier = Modifier.padding(top = 32.dp),
+                storeImageUrls = storeModel.imageUrls
+            )
+        }
+    }
+}
+
+@Composable
+internal fun StoreItemImageRow(
+    modifier: Modifier = Modifier,
+    storeImageUrls: List<String> = listOf()
+) {
+    LazyRow(modifier = modifier) {
+        items(storeImageUrls, key = { it }) { storeImageUrl ->
+            AsyncImage(
+                model = storeImageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .size(96.dp)
+                    .clip(RoundedCornerShape(20.dp))
+            )
+        }
+    }
+}
+
+@Composable
+internal fun StoreItemTagRow(
+    modifier: Modifier = Modifier,
+    storeTypes: List<String> = listOf()
+) {
+    LazyRow(modifier = modifier) {
+        items(storeTypes, key = { it }) { storeType ->
+            Surface(
+                modifier = Modifier.padding(end = 4.dp),
+                shape = RoundedCornerShape(14.dp),
+                color = StoreType.valueOf(storeType).toColor().copy(alpha = 0.2f)
+            ) {
+                Text(
+                    text = StoreType.valueOf(storeType).tag,
+                    modifier = Modifier.padding(vertical = 8.dp, horizontal = 12.dp),
+                    color = StoreType.valueOf(storeType).toColor(),
+                    fontSize = 12.dp.toSp(),
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = pretendard
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun StoreItemHeader(
+    modifier: Modifier = Modifier,
+    storeName: String,
+    storeDistrict: String,
+    storeLocation: String,
+    onClick: () -> Unit
+) {
+    var isFavorite by remember { mutableStateOf(false) }
+    Row(modifier) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = storeName,
+                    color = Raisin_Black,
+                    fontSize = 16.dp.toSp(),
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = pretendard
+                )
+                Divider(
+                    modifier = Modifier
+                        .padding(horizontal = 4.dp)
+                        .size(width = 1.dp, height = 12.5.dp)
+                        .background(Raisin_Black.copy(alpha = 0.4f))
+                )
+                Text(
+                    text = String.format(stringResource(R.string.home_district_name), DistrictType.valueOf(storeDistrict).districtKr),
+                    color = Raisin_Black,
+                    fontSize = 12.dp.toSp(),
+                    fontWeight = FontWeight.Normal,
+                    fontFamily = pretendard
+                )
+                Spacer(modifier = Modifier.weight(1f))
+            }
+
+            Text(
+                text = storeLocation,
+                modifier = Modifier.padding(top = 4.dp),
+                color = Raisin_Black.copy(alpha = 0.6f),
+                fontSize = 12.dp.toSp(),
+                fontWeight = FontWeight.Normal,
+                fontFamily = pretendard
+            )
+        }
+
+        IconButton(
+            onClick = {
+                isFavorite = isFavorite.not()
+                onClick()
+            },
+            modifier = Modifier
+                .padding(end = 20.dp)
+                .size(24.dp)
+        ) {
+            Icon(
+                painter = painterResource(
+                    if (isFavorite) {
+                        R.drawable.ic_heart_sel
+                    } else {
+                        R.drawable.ic_heart
+                    }
+                ),
+                contentDescription = null,
+                tint = Color.Unspecified
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/org/prography/designsystem/component/Store.kt
+++ b/core/designsystem/src/main/java/org/prography/designsystem/component/Store.kt
@@ -21,9 +21,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.prography.designsystem.R
 import org.prography.designsystem.mapper.toColor
-import org.prography.designsystem.ui.theme.Old_Lace
-import org.prography.designsystem.ui.theme.Raisin_Black
-import org.prography.designsystem.ui.theme.pretendard
+import org.prography.designsystem.ui.theme.*
 import org.prography.domain.model.enums.DistrictType
 import org.prography.domain.model.enums.StoreType
 import org.prography.domain.model.store.StoreModel
@@ -91,8 +89,8 @@ internal fun StoreItemTagRow(
     modifier: Modifier = Modifier,
     storeTypes: List<String> = listOf()
 ) {
-    LazyRow(modifier = modifier) {
-        items(storeTypes, key = { it }) { storeType ->
+    Row(modifier) {
+        storeTypes.take(3).forEach { storeType ->
             Surface(
                 modifier = Modifier.padding(end = 4.dp),
                 shape = RoundedCornerShape(14.dp),
@@ -102,6 +100,22 @@ internal fun StoreItemTagRow(
                     text = StoreType.valueOf(storeType).tag,
                     modifier = Modifier.padding(vertical = 8.dp, horizontal = 12.dp),
                     color = StoreType.valueOf(storeType).toColor(),
+                    fontSize = 12.dp.toSp(),
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = pretendard
+                )
+            }
+        }
+
+        if (storeTypes.size > 3) {
+            Surface(
+                shape = RoundedCornerShape(14.dp),
+                color = Black
+            ) {
+                Text(
+                    text = "+${storeTypes.size - 3}",
+                    modifier = Modifier.padding(vertical = 8.dp, horizontal = 10.dp),
+                    color = White,
                     fontSize = 12.dp.toSp(),
                     fontWeight = FontWeight.Bold,
                     fontFamily = pretendard

--- a/core/designsystem/src/main/res/drawable/ic_heart.xml
+++ b/core/designsystem/src/main/res/drawable/ic_heart.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M11.245,19.001L11.244,19C8.983,16.904 7.165,15.216 5.904,13.64C4.652,12.074 4.023,10.708 4.023,9.268C4.023,6.913 5.813,5.114 8.073,5.114C9.358,5.114 10.609,5.729 11.426,6.701L12,7.385L12.574,6.701C13.39,5.729 14.642,5.114 15.927,5.114C18.187,5.114 19.977,6.913 19.977,9.268C19.977,10.708 19.348,12.074 18.096,13.64C16.835,15.216 15.017,16.904 12.756,19L12.755,19.001L12,19.703L11.245,19.001Z"
+      android:strokeAlpha="0.8"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#222222"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_heart_sel.xml
+++ b/core/designsystem/src/main/res/drawable/ic_heart_sel.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,20.727L10.734,19.55C6.24,15.386 3.273,12.63 3.273,9.268C3.273,6.513 5.385,4.364 8.073,4.364C9.591,4.364 11.049,5.086 12,6.219C12.951,5.086 14.409,4.364 15.927,4.364C18.615,4.364 20.727,6.513 20.727,9.268C20.727,12.63 17.76,15.386 13.265,19.55L12,20.727Z"
+      android:fillColor="#222222"/>
+</vector>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="home_current_location">현재 위치</string>
     <string name="home_current_map_location">현재 지도 위치</string>
     <string name="home_num_of_cake_shop">%d개의 케이크샵</string>
+    <string name="home_district_name">%s구</string>
 
     <!-- home_detail -->
     <string name="home_detail_app_bar">상세정보</string>
@@ -25,4 +26,5 @@
     <string name="home_detail_opening">영업중</string>
     <string name="home_detail_blog_review">블로그 리뷰</string>
     <string name="home_detail_blog_review_more">블로그 리뷰 더 보기</string>
+
 </resources>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -9,8 +9,7 @@
     <string name="home_filter">Filter</string>
     <string name="home_filter_recommend">원하는 디자인의 케이크 샵을 추천해 드려요!</string>
     <string name="home_apply">적용</string>
-    <string name="home_current_location">현재 위치</string>
-    <string name="home_current_map_location">현재 지도 위치</string>
+    <string name="home_near_by_cake_shops">이 근처 케이크샵</string>
     <string name="home_num_of_cake_shop">%d개의 케이크샵</string>
     <string name="home_district_name">%s구</string>
 

--- a/core/network/src/main/java/org/prography/network/CakkService.kt
+++ b/core/network/src/main/java/org/prography/network/CakkService.kt
@@ -9,6 +9,7 @@ object CakkService {
         const val DISTRICT_LIST = "api/store/district/count"
         const val STORE_BLOG = "blog"
         const val STORE_RELOAD = "api/store/reload"
+        const val STORE_TYPE = "type"
     }
 
     object Parameter {

--- a/core/network/src/main/java/org/prography/network/api/dto/response/StoreReloadResponse.kt
+++ b/core/network/src/main/java/org/prography/network/api/dto/response/StoreReloadResponse.kt
@@ -29,6 +29,7 @@ data class StoreReloadResponse(
         location = location,
         latitude = latitude,
         longitude = longitude,
+        imageUrls = imageUrls,
         storeTypes = storeTypes
     )
 }

--- a/core/network/src/main/java/org/prography/network/api/dto/response/StoreResponse.kt
+++ b/core/network/src/main/java/org/prography/network/api/dto/response/StoreResponse.kt
@@ -14,6 +14,7 @@ data class StoreResponse(
     val location: String,
     val latitude: Double,
     val longitude: Double,
+    val imageUrls: List<String>,
     val storeTypes: List<String>,
 ) {
     fun toModel() = StoreModel(
@@ -26,6 +27,7 @@ data class StoreResponse(
         location = location,
         latitude = latitude,
         longitude = longitude,
+        imageUrls = imageUrls,
         storeTypes = storeTypes
     )
 }

--- a/core/network/src/main/java/org/prography/network/api/dto/response/StoreTypeResponse.kt
+++ b/core/network/src/main/java/org/prography/network/api/dto/response/StoreTypeResponse.kt
@@ -1,0 +1,15 @@
+package org.prography.network.api.dto.response
+
+import kotlinx.serialization.Serializable
+import org.prography.domain.model.store.StoreModel
+
+@Serializable
+data class StoreTypeResponse(
+    val storeId: Int,
+    val types: List<String>
+) {
+    fun toModel() = StoreModel(
+        id = storeId,
+        storeTypes = types
+    )
+}

--- a/data/src/main/java/org/prography/cakk/data/datasource/StoreRemoteSource.kt
+++ b/data/src/main/java/org/prography/cakk/data/datasource/StoreRemoteSource.kt
@@ -9,6 +9,7 @@ import org.prography.network.CakkService.Endpoint.STORE_BLOG
 import org.prography.network.CakkService.Endpoint.STORE_DETAIL
 import org.prography.network.CakkService.Endpoint.STORE_LIST
 import org.prography.network.CakkService.Endpoint.STORE_RELOAD
+import org.prography.network.CakkService.Endpoint.STORE_TYPE
 import org.prography.network.CakkService.Parameter.DISTRICT
 import org.prography.network.CakkService.Parameter.NORTH_EAST_LATITUDE
 import org.prography.network.CakkService.Parameter.NORTH_EAST_LONGITUDE
@@ -17,10 +18,7 @@ import org.prography.network.CakkService.Parameter.SOUTH_WEST_LATITUDE
 import org.prography.network.CakkService.Parameter.SOUTH_WEST_LONGITUDE
 import org.prography.network.CakkService.Parameter.STORETYPE
 import org.prography.network.CakkService.Parameter.STORE_TYPES
-import org.prography.network.api.dto.response.StoreBlogResponse
-import org.prography.network.api.dto.response.StoreDetailResponse
-import org.prography.network.api.dto.response.StoreReloadResponse
-import org.prography.network.api.dto.response.StoreResponse
+import org.prography.network.api.dto.response.*
 import javax.inject.Inject
 
 class StoreRemoteSource @Inject constructor(
@@ -33,6 +31,14 @@ class StoreRemoteSource @Inject constructor(
                 parameter(DISTRICT, district)
                 parameter(STORETYPE, storeTypes)
                 parameter(PAGE, page)
+            }
+        )
+    }
+
+    fun fetchStoreType(storeId: Int): Flow<StoreTypeResponse> = flow {
+        emit(
+            httpClient.get {
+                url("$BASE_URL$STORE_DETAIL/$storeId/$STORE_TYPE")
             }
         )
     }

--- a/data/src/main/java/org/prography/cakk/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/org/prography/cakk/data/repository/StoreRepositoryImpl.kt
@@ -17,6 +17,9 @@ class StoreRepositoryImpl @Inject constructor(
     override fun fetchStoreList(district: String, storeTypes: String, page: Int): Flow<List<StoreModel>> =
         storeRemoteSource.fetchStoreList(district, storeTypes, page).map { it.toModel() }
 
+    override fun fetchStoreType(storeId: Int): Flow<StoreModel> =
+        storeRemoteSource.fetchStoreType(storeId).map { it.toModel() }
+
     override fun fetchDetailStore(storeId: Int): Flow<StoreDetailModel> =
         storeRemoteSource.fetchDetailStore(storeId).map { it.toModel() }
 

--- a/domain/src/main/java/org/prography/domain/model/store/StoreModel.kt
+++ b/domain/src/main/java/org/prography/domain/model/store/StoreModel.kt
@@ -10,5 +10,6 @@ data class StoreModel(
     val location: String = "",
     val latitude: Double = 0.0,
     val longitude: Double = 0.0,
+    val imageUrls: List<String> = listOf(),
     val storeTypes: List<String> = listOf(),
 )

--- a/domain/src/main/java/org/prography/domain/repository/StoreRepository.kt
+++ b/domain/src/main/java/org/prography/domain/repository/StoreRepository.kt
@@ -8,6 +8,8 @@ import org.prography.domain.model.store.StoreModel
 interface StoreRepository {
     fun fetchStoreList(district: String, storeTypes: String, page: Int): Flow<List<StoreModel>>
 
+    fun fetchStoreType(storeId: Int): Flow<StoreModel>
+
     fun fetchDetailStore(storeId: Int): Flow<StoreDetailModel>
 
     fun fetchStoreBlog(storeId: Int): Flow<StoreBlogModel>

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.flow.filter
 import org.prography.designsystem.R
 import org.prography.designsystem.component.StoreItemContent
 import org.prography.designsystem.mapper.toBackgroundColor
-import org.prography.designsystem.mapper.toColor
 import org.prography.designsystem.mapper.toIcon
 import org.prography.designsystem.ui.theme.*
 import org.prography.domain.model.store.StoreModel
@@ -506,97 +505,10 @@ private fun CakeStoreContent(
             modifier = Modifier.padding(top = 22.dp),
         ) {
             items(storeList) { store ->
-//                Surface(
-//                    modifier = Modifier
-//                        .padding(horizontal = 16.dp)
-//                        .fillMaxWidth()
-//                        .clickable { onNavigateToDetail(store.id) },
-//                    shape = RoundedCornerShape(24.dp),
-//                    color = Old_Lace
-//                ) {
-//                    Column {
-//                        StoreInfo(store)
-//                        Spacer(modifier = Modifier.height(48.dp))
-//                        StoreTags(store)
-//                    }
-//                }
                 StoreItemContent(
                     modifier = Modifier.fillMaxWidth(),
-                    storeModel = store
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun StoreInfo(store: StoreModel) {
-    Row(
-        modifier = Modifier.padding(start = 20.dp, top = 20.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = store.name,
-            color = Raisin_Black,
-            fontFamily = pretendard,
-            fontWeight = FontWeight.Bold,
-            fontSize = 16.dp.toSp(),
-        )
-        Divider(
-            modifier = Modifier
-                .padding(horizontal = 4.dp)
-                .size(width = 1.dp, height = 12.5.dp)
-                .background(Raisin_Black.copy(alpha = 0.4f))
-        )
-        Text(
-            text = String.format(stringResource(R.string.home_district_name), DistrictType.valueOf(store.district).districtKr),
-            color = Raisin_Black,
-            fontFamily = pretendard,
-            fontWeight = FontWeight.Normal,
-            fontSize = 12.dp.toSp(),
-        )
-    }
-    Text(
-        text = store.location,
-        modifier = Modifier.padding(start = 20.dp, top = 12.dp),
-        color = Raisin_Black.copy(alpha = 0.6f),
-        fontFamily = pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.dp.toSp(),
-    )
-}
-
-@Composable
-private fun StoreTags(store: StoreModel) {
-    Row(modifier = Modifier.padding(start = 20.dp, bottom = 20.dp)) {
-        store.storeTypes.forEach { storeType ->
-            Surface(
-                shape = RoundedCornerShape(14.dp),
-                color = StoreType.valueOf(storeType).toColor().copy(alpha = 0.2f)
-            ) {
-                Text(
-                    text = StoreType.valueOf(storeType).tag,
-                    modifier = Modifier.padding(vertical = 8.dp, horizontal = 12.dp),
-                    color = StoreType.valueOf(storeType).toColor(),
-                    fontSize = 12.dp.toSp(),
-                    fontFamily = pretendard,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-            Spacer(modifier = Modifier.width(4.dp))
-        }
-        if (store.storeTypes.size - 3 > 0) {
-            Surface(
-                shape = RoundedCornerShape(14.dp),
-                color = Black
-            ) {
-                Text(
-                    text = "+${store.storeTypes.size - 3}",
-                    modifier = Modifier.padding(vertical = 8.dp, horizontal = 10.dp),
-                    color = White,
-                    fontSize = 12.dp.toSp(),
-                    fontFamily = pretendard,
-                    fontWeight = FontWeight.Bold
+                    storeModel = store,
+                    onClick = { onNavigateToDetail(store.id) }
                 )
             }
         }

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -49,6 +49,7 @@ import org.prography.domain.model.enums.StoreType
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import org.prography.designsystem.R
+import org.prography.designsystem.component.StoreItemContent
 import org.prography.designsystem.mapper.toBackgroundColor
 import org.prography.designsystem.mapper.toColor
 import org.prography.designsystem.mapper.toIcon
@@ -392,7 +393,8 @@ private fun FilterSelectButton(
             .fillMaxWidth()
             .padding(bottom = 4.dp)
             .clickable(enabled = selectFilter.count { it } > 0) {
-                StoreType.values()
+                StoreType
+                    .values()
                     .forEachIndexed { index, storeType ->
                         if (selectFilter[index]) filters.value += "${storeType.name},"
                     }
@@ -504,21 +506,24 @@ private fun CakeStoreContent(
             modifier = Modifier.padding(top = 22.dp),
         ) {
             items(storeList) { store ->
-                Surface(
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth()
-                        .clickable { onNavigateToDetail(store.id) },
-                    shape = RoundedCornerShape(24.dp),
-                    color = Old_Lace
-                ) {
-                    Column {
-                        StoreInfo(store)
-                        Spacer(modifier = Modifier.height(48.dp))
-                        StoreTags(store)
-                    }
-                }
-                Spacer(modifier = Modifier.height(12.dp))
+//                Surface(
+//                    modifier = Modifier
+//                        .padding(horizontal = 16.dp)
+//                        .fillMaxWidth()
+//                        .clickable { onNavigateToDetail(store.id) },
+//                    shape = RoundedCornerShape(24.dp),
+//                    color = Old_Lace
+//                ) {
+//                    Column {
+//                        StoreInfo(store)
+//                        Spacer(modifier = Modifier.height(48.dp))
+//                        StoreTags(store)
+//                    }
+//                }
+                StoreItemContent(
+                    modifier = Modifier.fillMaxWidth(),
+                    storeModel = store
+                )
             }
         }
     }
@@ -535,19 +540,20 @@ private fun StoreInfo(store: StoreModel) {
             color = Raisin_Black,
             fontFamily = pretendard,
             fontWeight = FontWeight.Bold,
-            fontSize = 18.dp.toSp(),
+            fontSize = 16.dp.toSp(),
         )
         Divider(
             modifier = Modifier
                 .padding(horizontal = 4.dp)
-                .size(width = 1.dp, height = 12.dp)
+                .size(width = 1.dp, height = 12.5.dp)
+                .background(Raisin_Black.copy(alpha = 0.4f))
         )
         Text(
-            text = DistrictType.valueOf(store.district).districtKr,
+            text = String.format(stringResource(R.string.home_district_name), DistrictType.valueOf(store.district).districtKr),
             color = Raisin_Black,
             fontFamily = pretendard,
             fontWeight = FontWeight.Normal,
-            fontSize = 16.dp.toSp(),
+            fontSize = 12.dp.toSp(),
         )
     }
     Text(
@@ -556,7 +562,7 @@ private fun StoreInfo(store: StoreModel) {
         color = Raisin_Black.copy(alpha = 0.6f),
         fontFamily = pretendard,
         fontWeight = FontWeight.Normal,
-        fontSize = 14.dp.toSp(),
+        fontSize = 12.dp.toSp(),
     )
 }
 

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -125,16 +125,10 @@ fun HomeScreen(
 
     LaunchedEffect(homeViewModel) {
         if (homeState.value.storeModels.isEmpty()) {
-            if (districtsArg.isEmpty()) {
-                homeViewModel.sendAction(HomeUiAction.LoadStoreList(listOf("JONGNO"), StoreType.values().joinToString(",") { it.name }))
-            } else {
-                homeViewModel.sendAction(
-                    HomeUiAction.LoadStoreList(
-                        districtsArg.split(" "),
-                        StoreType.values().joinToString(",") { it.name }
-                    )
-                )
-            }
+            homeViewModel.fetchStoreList(
+                districts = if (districtsArg.isEmpty()) listOf("JONGNO") else districtsArg.split(" "),
+                storeTypes = StoreType.values().joinToString(",") { it.name }
+            )
         }
     }
 }
@@ -197,15 +191,15 @@ private fun BottomSheet(
                             onDragEnd = {
                                 expandedType = when {
                                     offsetY >= (screenHeight / 1.5).toFloat() -> {
-                                        homeViewModel.sendAction(HomeUiAction.BottomSheetExpandFull)
+                                        homeViewModel.changeBottomSheetState(ExpandedType.FULL)
                                         ExpandedType.FULL
                                     }
                                     offsetY >= (screenHeight / 4).toFloat() && offsetY < (screenHeight / 1.5).toFloat() -> {
-                                        homeViewModel.sendAction(HomeUiAction.BottomSheetExpandQuarter)
+                                        homeViewModel.changeBottomSheetState(ExpandedType.QUARTER)
                                         ExpandedType.QUARTER
                                     }
                                     else -> {
-                                        homeViewModel.sendAction(HomeUiAction.BottomSheetExpandCollapsed)
+                                        homeViewModel.changeBottomSheetState(ExpandedType.COLLAPSED)
                                         ExpandedType.COLLAPSED
                                     }
                                 }
@@ -225,7 +219,7 @@ private fun BottomSheet(
                         onNavigateToOnBoarding = onNavigateToOnBoarding,
                         onNavigateToDetail = onNavigateToDetail,
                         openFilterSheet = {
-                            homeViewModel.sendAction(HomeUiAction.BottomSheetExpandHalf)
+                            homeViewModel.changeBottomSheetState(ExpandedType.HALF)
                             expandedType = ExpandedType.HALF
                             offsetY = expandedType
                                 .getByScreenHeight(expandedType, screenHeight, statusBarHeight, offsetY)
@@ -300,7 +294,7 @@ private fun FilterTopBar(
                 .padding(top = 22.dp)
                 .align(Alignment.End)
                 .clickable {
-                    homeViewModel.sendAction(HomeUiAction.BottomSheetExpandQuarter)
+                    homeViewModel.changeBottomSheetState(ExpandedType.QUARTER)
                     backToCakeStore()
                 },
         )
@@ -397,13 +391,11 @@ private fun FilterSelectButton(
                     .forEachIndexed { index, storeType ->
                         if (selectFilter[index]) filters.value += "${storeType.name},"
                     }
-                homeViewModel.sendAction(
-                    HomeUiAction.LoadStoreList(
-                        districtsArg.split(" "),
-                        filters.value
-                    )
+                homeViewModel.fetchStoreList(
+                    districts = districtsArg.split(" "),
+                    storeTypes = filters.value
                 )
-                homeViewModel.sendAction(HomeUiAction.BottomSheetExpandQuarter)
+                homeViewModel.changeBottomSheetState(ExpandedType.QUARTER)
                 backToCakeStore()
             },
         shape = RoundedCornerShape(15.dp),

--- a/feature/home/src/main/java/org/prography/home/HomeScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeScreen.kt
@@ -480,12 +480,12 @@ private fun CakeStoreContent(
         CakkStoreTopBar(
             modifier = Modifier.align(Alignment.Start),
             title = if (isReload) {
-                stringResource(id = R.string.home_current_map_location)
+                stringResource(id = R.string.home_near_by_cake_shops)
             } else {
                 if (districts.isNotEmpty()) {
                     districts.joinToString { it.districtKr }
                 } else {
-                    stringResource(id = R.string.home_current_location)
+                    stringResource(id = R.string.home_near_by_cake_shops)
                 }
             },
             storeCount = storeCount,

--- a/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
@@ -5,12 +5,9 @@ import org.prography.domain.model.store.StoreModel
 
 sealed class HomeUiAction : BaseAction {
     object Loading : HomeUiAction()
+    data class LoadStoreList(val storeModels: List<StoreModel>) : HomeUiAction()
 
-    data class LoadStoreList(val districts: List<String>, val storeTypes: String) : HomeUiAction()
-
-    data class LoadedStoreList(val storeModels: List<StoreModel>) : HomeUiAction()
-
-    data class LoadedStoreType(val storeModel: StoreModel) : HomeUiAction()
+    data class LoadStoreType(val storeModel: StoreModel) : HomeUiAction()
 
     data class ReloadStore(val storeModels: List<StoreModel>) : HomeUiAction()
 

--- a/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeUiAction.kt
@@ -10,6 +10,8 @@ sealed class HomeUiAction : BaseAction {
 
     data class LoadedStoreList(val storeModels: List<StoreModel>) : HomeUiAction()
 
+    data class LoadedStoreType(val storeModel: StoreModel) : HomeUiAction()
+
     data class ReloadStore(val storeModels: List<StoreModel>) : HomeUiAction()
 
     object BottomSheetExpandFull : HomeUiAction()

--- a/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/HomeViewModel.kt
@@ -20,11 +20,7 @@ class HomeViewModel @Inject constructor(
         HomeUiAction.BottomSheetExpandCollapsed -> currentState.copy(lastExpandedType = ExpandedType.COLLAPSED)
         HomeUiAction.BottomSheetExpandHalf -> currentState.copy(lastExpandedType = ExpandedType.HALF)
         HomeUiAction.Loading -> currentState
-        is HomeUiAction.LoadStoreList -> {
-            fetchStoreList(action.districts, action.storeTypes)
-            currentState
-        }
-        is HomeUiAction.LoadedStoreType -> {
+        is HomeUiAction.LoadStoreType -> {
             currentState.copy(
                 storeModels = currentState.storeModels.map {
                     if (it.id == action.storeModel.id) {
@@ -35,7 +31,7 @@ class HomeViewModel @Inject constructor(
                 }
             )
         }
-        is HomeUiAction.LoadedStoreList -> {
+        is HomeUiAction.LoadStoreList -> {
             currentState.copy(storeModels = currentState.storeModels + action.storeModels, isReload = false)
         }
         is HomeUiAction.ReloadStore -> {
@@ -43,15 +39,25 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun changeBottomSheetState(expandedType: ExpandedType) {
+        when (expandedType) {
+            ExpandedType.FULL -> sendAction(HomeUiAction.BottomSheetExpandFull)
+            ExpandedType.QUARTER -> sendAction(HomeUiAction.BottomSheetExpandQuarter)
+            ExpandedType.HALF -> sendAction(HomeUiAction.BottomSheetExpandHalf)
+            ExpandedType.COLLAPSED -> sendAction(HomeUiAction.BottomSheetExpandCollapsed)
+            else -> return
+        }
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun fetchStoreList(districts: List<String>, storeTypes: String) {
+    fun fetchStoreList(districts: List<String>, storeTypes: String) {
         districts.sorted().asFlow()
             .flatMapMerge { storeRepository.fetchStoreList(it, storeTypes, 1) }
-            .onEach { sendAction(HomeUiAction.LoadedStoreList(it)) }
+            .onEach { sendAction(HomeUiAction.LoadStoreList(it)) }
             .flatMapMerge { it.asFlow() }
             .flatMapMerge { storeRepository.fetchStoreType(it.id) }
             .onStart { sendAction(HomeUiAction.Loading) }
-            .onEach { sendAction(HomeUiAction.LoadedStoreType(it)) }
+            .onEach { sendAction(HomeUiAction.LoadStoreType(it)) }
             .launchIn(viewModelScope)
     }
 
@@ -79,7 +85,7 @@ class HomeViewModel @Inject constructor(
             .flatMapMerge { it.asFlow() }
             .flatMapMerge { storeRepository.fetchStoreType(it.id) }
             .onStart { sendAction(HomeUiAction.Loading) }
-            .onEach { sendAction(HomeUiAction.LoadedStoreType(it)) }
+            .onEach { sendAction(HomeUiAction.LoadStoreType(it)) }
             .launchIn(viewModelScope)
     }
 }

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailAction.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailAction.kt
@@ -6,8 +6,6 @@ import org.prography.domain.model.store.StoreDetailModel
 
 sealed class HomeDetailAction : BaseAction {
     object Loading : HomeDetailAction()
-    data class LoadDetailInfo(val id: Int) : HomeDetailAction()
-    data class LoadedDetailInfo(val storeDetailModel: StoreDetailModel) : HomeDetailAction()
-    data class LoadBlogInfos(val id: Int) : HomeDetailAction()
-    data class LoadedBlogInfos(val blogPosts: List<BlogPostModel>) : HomeDetailAction()
+    data class LoadDetailInfo(val storeDetailModel: StoreDetailModel) : HomeDetailAction()
+    data class LoadBlogInfos(val blogPosts: List<BlogPostModel>) : HomeDetailAction()
 }

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailScreen.kt
@@ -31,10 +31,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import org.prography.domain.model.enums.StoreType
 import org.prography.designsystem.R
 import org.prography.designsystem.mapper.toColor
 import org.prography.designsystem.ui.theme.*
+import org.prography.domain.model.enums.StoreType
 import org.prography.domain.model.store.BlogPostModel
 import org.prography.utility.extensions.toSp
 
@@ -45,8 +45,8 @@ fun HomeDetailScreen(
     storeId: Int,
 ) {
     LaunchedEffect(storeId) {
-        homeDetailViewModel.sendAction(HomeDetailAction.LoadDetailInfo(storeId))
-        homeDetailViewModel.sendAction(HomeDetailAction.LoadBlogInfos(storeId))
+        homeDetailViewModel.fetchDetailStore(storeId)
+        homeDetailViewModel.fetchStoreBlogInfos(storeId)
     }
 
     val storeDetailState = homeDetailViewModel.state.collectAsStateWithLifecycle()

--- a/feature/home/src/main/java/org/prography/home/detail/HomeDetailViewModel.kt
+++ b/feature/home/src/main/java/org/prography/home/detail/HomeDetailViewModel.kt
@@ -18,32 +18,24 @@ class HomeDetailViewModel @Inject constructor(
     override fun reduceState(currentState: HomeDetailState, action: HomeDetailAction): HomeDetailState = when (action) {
         HomeDetailAction.Loading -> currentState
         is HomeDetailAction.LoadDetailInfo -> {
-            fetchDetailStore(action.id)
-            currentState
-        }
-        is HomeDetailAction.LoadedDetailInfo -> {
             currentState.copy(storeDetailModel = action.storeDetailModel)
         }
         is HomeDetailAction.LoadBlogInfos -> {
-            fetchStoreBlogInfos(action.id)
-            currentState
-        }
-        is HomeDetailAction.LoadedBlogInfos -> {
             currentState.copy(blogPosts = action.blogPosts)
         }
     }
 
-    private fun fetchDetailStore(id: Int) {
+    fun fetchDetailStore(id: Int) {
         storeRepository.fetchDetailStore(id)
             .onStart { sendAction(HomeDetailAction.Loading) }
-            .onEach { sendAction(HomeDetailAction.LoadedDetailInfo(it)) }
+            .onEach { sendAction(HomeDetailAction.LoadDetailInfo(it)) }
             .launchIn(viewModelScope)
     }
 
-    private fun fetchStoreBlogInfos(id: Int) {
+    fun fetchStoreBlogInfos(id: Int) {
         storeRepository.fetchStoreBlog(id)
             .onStart { sendAction(HomeDetailAction.Loading) }
-            .onEach { sendAction(HomeDetailAction.LoadedBlogInfos(it.blogPosts)) }
+            .onEach { sendAction(HomeDetailAction.LoadBlogInfos(it.blogPosts)) }
             .launchIn(viewModelScope)
     }
 }

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingAction.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingAction.kt
@@ -5,9 +5,8 @@ import org.prography.domain.model.district.DistrictModel
 
 sealed class OnBoardingAction : BaseAction {
     object Loading : OnBoardingAction()
-    object LoadDistrictList : OnBoardingAction()
 
-    data class LoadedDistrictList(
+    data class LoadDistrictList(
         val districts: List<DistrictModel>
     ) : OnBoardingAction()
 }

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingScreen.kt
@@ -33,7 +33,7 @@ fun OnBoardingScreen(
     onNavigateHome: (String, Int) -> Unit
 ) {
     LaunchedEffect(true) {
-        onBoardingViewModel.sendAction(OnBoardingAction.LoadDistrictList)
+        onBoardingViewModel.fetchDistrictList()
     }
 
     val districtListState = onBoardingViewModel.state.collectAsStateWithLifecycle()

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingSideEffect.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingSideEffect.kt
@@ -1,5 +1,0 @@
-package org.prography.onboarding
-
-import org.prography.base.BaseSideEffect
-
-sealed class OnBoardingSideEffect : BaseSideEffect

--- a/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingViewModel.kt
+++ b/feature/onboarding/src/main/java/org/prography/onboarding/OnBoardingViewModel.kt
@@ -6,31 +6,27 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import org.prography.base.BaseViewModel
-import org.prography.utility.mapper.toGroup
 import org.prography.domain.repository.DistrictRepository
+import org.prography.utility.mapper.toGroup
 import javax.inject.Inject
 
 @HiltViewModel
 class OnBoardingViewModel @Inject constructor(
     private val districtRepository: DistrictRepository
-) : BaseViewModel<OnBoardingAction, OnBoardingState, OnBoardingSideEffect>(
+) : BaseViewModel<OnBoardingAction, OnBoardingState, Nothing>(
     initialState = OnBoardingState()
 ) {
     override fun reduceState(currentState: OnBoardingState, action: OnBoardingAction): OnBoardingState = when (action) {
         OnBoardingAction.Loading -> currentState
-        OnBoardingAction.LoadDistrictList -> {
-            fetchDistrictList()
-            currentState
-        }
-        is OnBoardingAction.LoadedDistrictList -> {
+        is OnBoardingAction.LoadDistrictList -> {
             currentState.copy(districtGroups = action.districts.toGroup())
         }
     }
 
-    private fun fetchDistrictList() {
+    fun fetchDistrictList() {
         districtRepository.fetchDistrictList()
             .onStart { sendAction(OnBoardingAction.Loading) }
-            .onEach { sendAction(OnBoardingAction.LoadedDistrictList(it)) }
+            .onEach { sendAction(OnBoardingAction.LoadDistrictList(it)) }
             .launchIn(viewModelScope)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ androidxNavigation = "2.5.3"
 # 3rd-party
 kotlin = "1.8.10"
 dagger = "2.45"
-coil = "2.3.0"
+coil = "2.4.0"
 timber = "5.0.1"
 lottie = "6.0.0"
 kotlin-coroutine = "1.6.4"
@@ -84,7 +84,7 @@ ktor-serialization = { group = "io.ktor", name = "ktor-client-serialization", ve
 ktor-logging = { group = "io.ktor", name = "ktor-client-logging-jvm", version.ref = "ktor" }
 ## etc
 material = "com.google.android.material:material:1.8.0"
-coil-core = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 lottie = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
 naver-map = { group = "io.github.fornewid", name = "naver-map-compose", version.ref = "naver-map" }


### PR DESCRIPTION
## Related issue
- closed #48 

## Work Description
홈 화면의 바텀 시트 리스트 데이터의 UI 변경되어 수정 개발

## Screenshot (선택)
<img src="https://github.com/Prography-8th-team8/Cakk-AOS/assets/34837583/5b1a275b-a072-4f5a-8b63-3c73527d2417" width=300 height=670/>


## Completed Tasks
- [x] 바텀 시트 리스트 데이터 UI 변경
- [x] 케이크샵 태그 API 추가
- [x] View에서 Action을 직접 호출하지 않도록 리팩토링
